### PR TITLE
make external application chooser cells editable

### DIFF
--- a/dialogs.cpp
+++ b/dialogs.cpp
@@ -1187,10 +1187,14 @@ AppMgmtDialog::AppMgmtDialog(QWidget *parent) : QDialog(parent)
 	appsTable->	setShowGrid(false);
 
 	QHBoxLayout *addRemoveHbox = new QHBoxLayout;
-    QPushButton *addButton = new QPushButton(tr("Add"));
+    QPushButton *addButton = new QPushButton(tr("Choose application"));
    	addButton->setIcon(QIcon::fromTheme("list-add"));
 	connect(addButton, SIGNAL(clicked()), this, SLOT(add()));
 	addRemoveHbox->addWidget(addButton, 0, Qt::AlignRight);
+    QPushButton *entryButton = new QPushButton(tr("Add new entry"));
+        entryButton->setIcon(QIcon::fromTheme("list-add"));
+	connect(entryButton, SIGNAL(clicked()), this, SLOT(entry()));
+	addRemoveHbox->addWidget(entryButton, 0, Qt::AlignRight);
     QPushButton *removeButton = new QPushButton(tr("Remove"));
    	removeButton->setIcon(QIcon::fromTheme("list-remove"));
 	connect(removeButton, SIGNAL(clicked()), this, SLOT(remove()));
@@ -1227,10 +1231,10 @@ void AppMgmtDialog::ok()
 	GData::externalApps.clear();
     for (int i = 0; i < row ; ++i)
     {
+	    if ( appsTableModel->itemFromIndex(appsTableModel->index(i, 0))->text() != "new entry" )
 		GData::externalApps[appsTableModel->itemFromIndex(appsTableModel->index(i, 0))->text()] =
 						appsTableModel->itemFromIndex(appsTableModel->index(i, 1))->text();
-   	}
-
+    }
 	accept();
 }
 
@@ -1243,6 +1247,13 @@ void AppMgmtDialog::add()
 	QFileInfo fileInfo = QFileInfo(fileName);
 	QString appName = fileInfo.fileName();
 	addTableModelItem(appsTableModel, appName, fileName);
+}
+
+void AppMgmtDialog::entry()
+{
+	int atRow = appsTableModel->rowCount();
+	QStandardItem *itemKey = new QStandardItem(QString(tr("new entry")));
+	appsTableModel->insertRow(atRow, itemKey);
 }
 
 void AppMgmtDialog::remove()

--- a/dialogs.h
+++ b/dialogs.h
@@ -208,6 +208,7 @@ public slots:
 private slots:
 	void add();
 	void remove();
+	void entry();
 
 private:
 	QTableView *appsTable;


### PR DESCRIPTION
- allows changing menu-name of the external application
- allows adding additional arguments to the application

addresses issue #87 (or more precisly: makes it more accessible from UI).
