### PR TITLE
Fix issue #106: Keyboard shortcuts should be in a list and not a combo

### DIFF
--- a/dialogs.h
+++ b/dialogs.h
@@ -44,21 +44,15 @@ private:
 	bool abortOp;
 };
 
-class KeyGrabLineEdit : public QLineEdit
+class KeyGrabTableView : public QTableView
 {
 	Q_OBJECT
  
-public:
-	KeyGrabLineEdit(QWidget *parent, QComboBox *combo);
-
 public slots:
-	void clearShortcut();
+	void clearShortcut(const QModelIndex & index);
 
 protected:
 	void keyPressEvent(QKeyEvent *e);
-
-private:
-	QComboBox *keysCombo;
 };
 
 class SettingsDialog : public QDialog
@@ -75,7 +69,6 @@ private slots:
 	void pickThumbsTextColor();
 	void pickStartupDir();
 	void pickBgImage();
-	void setActionKeyText(const QString &text);
 
 public slots:
 	void abort();
@@ -104,7 +97,6 @@ private:
 	QCheckBox *reverseMouseCb;
 	QSpinBox *slideDelaySpin;
 	QCheckBox *slideRandomCb;
-	KeyGrabLineEdit *keyLine;
 	QRadioButton *startupDirRadios[3];
 	QLineEdit *startupDirEdit;
 	QLineEdit *thumbsBackImageEdit;


### PR DESCRIPTION
Fix issue #106: Keyboard shortcuts should be in a list and not a combo

Changed shortcuts combo to QTableView.

![tableview](https://cloud.githubusercontent.com/assets/290585/5329531/04f13806-7db3-11e4-9098-aa5cfd8d5f3c.jpg)
