### PR TITLE
Delete action enhancements

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -57,8 +57,7 @@ private slots:
 	void setIncludeSubFolders();
 	void showSettings();
 	void toggleFullScreen();
-	void updateActions(QWidget *old, QWidget *now);
-	void changeActionsBySelection(const QItemSelection&, const QItemSelection&);
+	void updateActions();
 	void reloadThumbsSlot();
 	void renameDir();
 	void setThumbviewWindowTitle();
@@ -345,6 +344,7 @@ private:
 	bool isValidPath(QString &path);
 	QString getSelectedPath();
 	void setCopyCutActions(bool setEnabled);
+	void setDeleteAction(bool setEnabled);
 	void wheelEvent(QWheelEvent *event);	
 	void copyOrCutThumbs(bool copy);
 	void showNewImageWarning(QWidget *parent);


### PR DESCRIPTION
I propose to enable or disable delete button based on currently selected widget only if deletable item are selected.
After change delete action also removes bookmarks.
Maybe we should also change delete label based on above criteria.