### PR TITLE
Fixes #179: hide expansion mark on empty dirs

### DIFF
--- a/fstree.cpp
+++ b/fstree.cpp
@@ -24,7 +24,7 @@ FSTree::FSTree(QWidget *parent) : QTreeView(parent)
 	setDragEnabled(true);
 	setDragDropMode(QAbstractItemView::InternalMove);
 
-	fsModel = new QFileSystemModel;
+	fsModel = new FSModel();
 	fsModel->setRootPath("");
 	setModelFlags();
 
@@ -39,6 +39,20 @@ FSTree::FSTree(QWidget *parent) : QTreeView(parent)
 								this, SLOT(resizeTreeColumn(const QModelIndex &)));
 	connect(this, SIGNAL(collapsed(const QModelIndex &)),
 								this, SLOT(resizeTreeColumn(const QModelIndex &)));
+}
+
+bool FSModel::hasChildren(const QModelIndex &parent) const
+{
+	// return false if item cant have children
+	if (parent.flags() &  Qt::ItemNeverHasChildren) {
+		return false;
+	}
+
+	if (filePath(parent) == "")
+		return true;
+
+	// return if at least one child exists
+	return QDirIterator(filePath(parent), filter() | QDir::NoDotAndDotDot, QDirIterator::NoIteratorFlags).hasNext();
 }
 
 QModelIndex FSTree::getCurrentIndex()

--- a/fstree.h
+++ b/fstree.h
@@ -22,13 +22,19 @@
 #ifndef FSTREE_H
 #define FSTREE_H
 
+class FSModel : public QFileSystemModel
+{
+public:
+	bool hasChildren(const QModelIndex &parent) const;
+};
+
 class FSTree : public QTreeView
 {
 	Q_OBJECT
 
 public:
 	FSTree(QWidget *parent);
-	QFileSystemModel *fsModel;
+	FSModel *fsModel;
 	QModelIndex getCurrentIndex();
 	void setModelFlags();
 


### PR DESCRIPTION
Fixed bug according to:
http://stackoverflow.com/questions/14545711/qfilesystemmodel-and-qtreeview-showing-dirs-only-how-to-hide-expansion-marks-ag
But it was not working as is because of empty paths returned by filePath(parent) - I have fixed it by adding:
if (filePath(parent) == "")
    return true;
But I do not know whether it will not cause any bad issues - I do not understand why this code returns empty paths and for now I do not have time to investigate this.