### PR TITLE
improvements regarding PKGBUILDs

### DIFF
--- a/Arch/PKGBUILD
+++ b/Arch/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=phototonic
-pkgver=1.5.48
+pkgver=1.5.54
 pkgrel=1
 pkgdesc="Image Viewer and Organizer"
 arch=('i686' 'x86_64')
@@ -7,18 +7,20 @@ url="http://oferkv.github.io/phototonic/"
 license=('GPL3')
 depends=('qt5-base' 'exiv2' 'libxkbcommon-x11')
 optdepends=('qt5-imageformats: TIFF and TGA support' 'qt5-svg: SVG support')
-source=("https://github.com/oferkv/phototonic/archive/v${pkgver}.tar.gz")
-md5sums=('d1a20189fba8ed1abda5c227d06cfe23')
 provides=('phototonic')
+source=("https://github.com/oferkv/phototonic/archive/06e2f123ac1f8f368dcb4db641c05d92f69f966b.tar.gz")
+md5sums=('f3b8d405cf3be8460c1347ce3c225340')
 
 build() {
-  cd "$srcdir/$pkgname-$pkgver"
-  qmake-qt5 PREFIX="/usr" QMAKE_CFLAGS_RELEASE="$CPPFLAGS $CFLAGS" QMAKE_CXXFLAGS_RELEASE="$CPPFLAGS $CXXFLAGS" QMAKE_LFLAGS_RELEASE="$LDFLAGS"
+  cd "$srcdir/$pkgname-06e2f123ac1f8f368dcb4db641c05d92f69f966b"
+  qmake-qt5 PREFIX="/usr" \
+            QMAKE_CFLAGS_RELEASE="$CPPFLAGS $CFLAGS" \
+            QMAKE_CXXFLAGS_RELEASE="$CPPFLAGS $CXXFLAGS" \
+            QMAKE_LFLAGS_RELEASE="$LDFLAGS"
   make
 }
 
 package() {
-  cd "$srcdir/$pkgname-$pkgver"
+  cd "$srcdir/$pkgname-06e2f123ac1f8f368dcb4db641c05d92f69f966b"
   make INSTALL_ROOT="$pkgdir/" install
 }
-

--- a/Arch/PKGBUILD.git
+++ b/Arch/PKGBUILD.git
@@ -1,20 +1,28 @@
 pkgname=phototonic-git
-pkgver=1
-pkgrel=7
+pkgver=1.5.53.g6a5608a
+pkgrel=1
 pkgdesc="Image Viewer and Organizer"
 arch=('i686' 'x86_64')
 url="http://oferkv.github.io/phototonic/"
 license=('GPL3')
 depends=('qt5-base' 'exiv2' 'libxkbcommon-x11')
 optdepends=('qt5-imageformats: TIFF and TGA support' 'qt5-svg: SVG support')
-source=("git://gitorious.org/phototonic/phototonic.git")
-md5sums=('SKIP')
 makedepends=('git')
 provides=('phototonic')
+source=("git+https://github.com/oferkv/phototonic.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/phototonic"
+  git describe --always | sed "s/^v//;s/-/./g"
+}
 
 build() {
   cd "$srcdir/phototonic"
-  qmake-qt5 PREFIX="/usr" QMAKE_CFLAGS_RELEASE="$CPPFLAGS $CFLAGS" QMAKE_CXXFLAGS_RELEASE="$CPPFLAGS $CXXFLAGS" QMAKE_LFLAGS_RELEASE="$LDFLAGS"
+  qmake-qt5 PREFIX="/usr" \
+            QMAKE_CFLAGS_RELEASE="$CPPFLAGS $CFLAGS" \
+            QMAKE_CXXFLAGS_RELEASE="$CPPFLAGS $CXXFLAGS" \
+            QMAKE_LFLAGS_RELEASE="$LDFLAGS"
   make
 }
 
@@ -22,4 +30,3 @@ package() {
   cd "$srcdir/phototonic"
   make INSTALL_ROOT="$pkgdir/" install
 }
-


### PR DESCRIPTION
This PR is just meant to propose some improvement regarding the Arch Linux PKGBUILDs. Both modified versions have been proven to work.

Regarding package phototonic-git the download source got changed. This was necessary as downloading via Git protocol on gitorious.org doesn't seem to work any more. While I was at it I migrated to GitHub and introduced HTTPS.
Package version isn't handled statically any more but derived from the checkout while building using PKGBUILD function pkgver().
Aside from this there's some minor polish making things a bit more handy, imho. The order of some lines was changed and qmake arguments were arranged in several lines.

In phototonic I took the liberty to do that polish, too. As a side-effect this transferred changes that had been made on aur.archlinux.org only to the GitHub repo.