### PR TITLE
Include user pictures directory to bookmarks by default

### DIFF
--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -2054,6 +2054,9 @@ void Phototonic::readSettings() {
         Settings::appSettings->setValue("showViewerToolbar", (bool) false);
         Settings::appSettings->setValue("smallToolbarIcons", (bool) true);
         Settings::bookmarkPaths.insert(QDir::homePath());
+        const QString picturesLocation = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+        if (!picturesLocation.isEmpty())
+            Settings::bookmarkPaths.insert(picturesLocation);
     }
 
     Settings::viewerBackgroundColor = Settings::appSettings->value(


### PR DESCRIPTION
This adds user standard path to pictures upon the first startup of phototonic.
The change will only be visible for those who have never started phototonic before as bookmarks are saved into config and re-read from it later on.