### PR TITLE
Move to trashcan implementation for Freedesktop

### DIFF
--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -28,6 +28,7 @@
 #include "ImagePreview.h"
 #include "FileListWidget.h"
 #include "RenameDialog.h"
+#include "Trashcan.h"
 
 #define THUMB_SIZE_MIN    25
 #define THUMB_SIZE_MAX    450
@@ -180,6 +181,7 @@ void Phototonic::createImageViewer() {
     imageViewer->addAction(copyImageAction);
     imageViewer->addAction(pasteImageAction);
     imageViewer->addAction(deleteAction);
+    imageViewer->addAction(moveToTrashAction);
     imageViewer->addAction(renameAction);
     imageViewer->addAction(CloseImageAction);
     imageViewer->addAction(fullScreenAction);
@@ -263,6 +265,7 @@ void Phototonic::createImageViewer() {
     imageViewer->ImagePopUpMenu->addAction(saveAsAction);
     imageViewer->ImagePopUpMenu->addAction(renameAction);
     imageViewer->ImagePopUpMenu->addAction(deleteAction);
+    imageViewer->ImagePopUpMenu->addAction(moveToTrashAction);
     imageViewer->ImagePopUpMenu->addAction(openWithMenuAction);
 
     addMenuSeparator(imageViewer->ImagePopUpMenu);
@@ -357,6 +360,11 @@ void Phototonic::createActions() {
     deleteAction->setObjectName("delete");
     deleteAction->setIcon(QIcon::fromTheme("edit-delete", QIcon(":/images/delete.png")));
     connect(deleteAction, SIGNAL(triggered()), this, SLOT(deleteOperation()));
+
+    moveToTrashAction = new QAction(tr("Move to Trash"), this);
+    moveToTrashAction->setObjectName("moveToTrash");
+    moveToTrashAction->setIcon(style()->standardPixmap(QStyle::SP_TrashIcon));
+    connect(moveToTrashAction, SIGNAL(triggered()), this, SLOT(moveToTrashOperation()));
 
     saveAction = new QAction(tr("Save"), this);
     saveAction->setObjectName("save");
@@ -689,6 +697,7 @@ void Phototonic::createMenus() {
     editMenu->addAction(renameAction);
     editMenu->addAction(removeMetadataAction);
     editMenu->addAction(deleteAction);
+    editMenu->addAction(moveToTrashAction);
     editMenu->addSeparator();
     editMenu->addAction(selectAllAction);
     editMenu->addAction(invertSelectionAction);
@@ -743,6 +752,7 @@ void Phototonic::createMenus() {
     thumbsViewer->addAction(renameAction);
     thumbsViewer->addAction(removeMetadataAction);
     thumbsViewer->addAction(deleteAction);
+    thumbsViewer->addAction(moveToTrashAction);
     addMenuSeparator(thumbsViewer);
     thumbsViewer->addAction(selectAllAction);
     thumbsViewer->addAction(invertSelectionAction);
@@ -758,6 +768,7 @@ void Phototonic::createToolBars() {
     editToolBar->addAction(copyAction);
     editToolBar->addAction(pasteAction);
     editToolBar->addAction(deleteAction);
+    editToolBar->addAction(moveToTrashAction);
     editToolBar->addAction(showClipboardAction);
     connect(editToolBar->toggleViewAction(), SIGNAL(triggered()), this, SLOT(setEditToolBarVisibility()));
 
@@ -817,6 +828,7 @@ void Phototonic::createToolBars() {
     imageToolBar->addAction(saveAction);
     imageToolBar->addAction(saveAsAction);
     imageToolBar->addAction(deleteAction);
+    imageToolBar->addAction(moveToTrashAction);
     imageToolBar->addSeparator();
     imageToolBar->addAction(zoomInAction);
     imageToolBar->addAction(zoomOutAction);
@@ -1659,7 +1671,82 @@ void Phototonic::loadCurrentImage(int currentRow) {
     thumbsViewer->setImageViewerWindowTitle();
 }
 
-void Phototonic::viewerDeleteFromViewer() {
+void Phototonic::deleteFromThumbsViewer(bool trash)
+{
+    // Deleting selected thumbnails
+    if (thumbsViewer->selectionModel()->selectedIndexes().size() < 1) {
+        setStatus(tr("No selection"));
+        return;
+    }
+
+    if (Settings::deleteConfirm) {
+        QMessageBox msgBox;
+        msgBox.setText(trash ? tr("Move selected images to trash can?") : tr("Permanently delete selected images?"));
+        msgBox.setWindowTitle(tr("Delete images"));
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::Yes);
+        msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
+        msgBox.setButtonText(QMessageBox::Cancel, tr("Cancel"));
+
+        if (msgBox.exec() != QMessageBox::Yes) {
+            return;
+        }
+    }
+
+    ProgressDialog *progressDialog = new ProgressDialog(this);
+    progressDialog->show();
+
+    int deleteFilesCount = 0;
+    bool deleteOk;
+    QList<int> rows;
+    int row;
+    QModelIndexList indexesList;
+    while ((indexesList = thumbsViewer->selectionModel()->selectedIndexes()).size()) {
+        QString fileNameFullPath = thumbsViewer->thumbsViewerModel->item(
+                indexesList.first().row())->data(thumbsViewer->FileNameRole).toString();
+        progressDialog->opLabel->setText("Deleting " + fileNameFullPath);
+        QString trashError;
+        deleteOk = trash ? (Trash::moveToTrash(fileNameFullPath, trashError) == Trash::Success) : QFile::remove(fileNameFullPath);
+
+        ++deleteFilesCount;
+        if (deleteOk) {
+            row = indexesList.first().row();
+            rows << row;
+            thumbsViewer->thumbsViewerModel->removeRow(row);
+        } else {
+            QMessageBox msgBox;
+            msgBox.critical(this, tr("Error"), trash ? trashError : tr("Failed to delete image."));
+            break;
+        }
+
+        Settings::filesList.removeOne(fileNameFullPath);
+
+        if (progressDialog->abortOp) {
+            break;
+        }
+    }
+
+    if (thumbsViewer->thumbsViewerModel->rowCount()) {
+        qSort(rows.begin(), rows.end());
+        row = rows.at(0);
+
+        if (row >= thumbsViewer->thumbsViewerModel->rowCount()) {
+            row = thumbsViewer->thumbsViewerModel->rowCount() - 1;
+        }
+
+        thumbsViewer->setCurrentRow(row);
+        thumbsViewer->selectThumbByRow(row);
+    }
+
+    progressDialog->close();
+    delete (progressDialog);
+
+    QString state = QString(tr("Deleted") + " " + tr("%n image(s)", "", deleteFilesCount));
+    setStatus(state);
+}
+
+void Phototonic::viewerDeleteFromViewer(bool trash) {
     if (imageViewer->isNewImage()) {
         showNewImageWarning(this);
         return;
@@ -1677,7 +1764,7 @@ void Phototonic::viewerDeleteFromViewer() {
     bool deleteConfirmed = true;
     if (Settings::deleteConfirm) {
         QMessageBox msgBox;
-        msgBox.setText(tr("Permanently delete") + " " + fileName);
+        msgBox.setText(trash ? tr("Move to trashcan") : tr("Permanently delete") + " " + fileName);
         msgBox.setWindowTitle(tr("Delete image"));
         msgBox.setIcon(QMessageBox::Warning);
         msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
@@ -1693,13 +1780,14 @@ void Phototonic::viewerDeleteFromViewer() {
     if (deleteConfirmed) {
         int currentRow = thumbsViewer->getCurrentRow();
 
-        ok = QFile::remove(imageViewer->viewerImageFullPath);
+        QString trashError;
+        ok = trash ? (Trash::moveToTrash(imageViewer->viewerImageFullPath, trashError) == Trash::Success) : QFile::remove(imageViewer->viewerImageFullPath);
         if (ok) {
             thumbsViewer->thumbsViewerModel->removeRow(currentRow);
             imageViewer->setFeedback(tr("Deleted ") + fileName);
         } else {
             QMessageBox msgBox;
-            msgBox.critical(this, tr("Error"), tr("Failed to delete image"));
+            msgBox.critical(this, tr("Error"), trash ? trashError : tr("Failed to delete image"));
             if (isFullScreen()) {
                 imageViewer->setCursorHiding(true);
             }
@@ -1731,80 +1819,20 @@ void Phototonic::deleteOperation() {
     }
 
     if (Settings::layoutMode == ImageViewWidget) {
-        viewerDeleteFromViewer();
+        viewerDeleteFromViewer(false);
         return;
     }
 
-    // Deleting selected thumbnails
-    if (thumbsViewer->selectionModel()->selectedIndexes().size() < 1) {
-        setStatus(tr("No selection"));
+    deleteFromThumbsViewer(false);
+}
+
+void Phototonic::moveToTrashOperation()
+{
+    if (Settings::layoutMode == ImageViewWidget) {
+        viewerDeleteFromViewer(true);
         return;
     }
-
-    if (Settings::deleteConfirm) {
-        QMessageBox msgBox;
-        msgBox.setText(tr("Permanently delete selected images?"));
-        msgBox.setWindowTitle(tr("Delete images"));
-        msgBox.setIcon(QMessageBox::Warning);
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
-        msgBox.setDefaultButton(QMessageBox::Yes);
-        msgBox.setButtonText(QMessageBox::Yes, tr("Yes"));
-        msgBox.setButtonText(QMessageBox::Cancel, tr("Cancel"));
-
-        if (msgBox.exec() != QMessageBox::Yes) {
-            return;
-        }
-    }
-
-    ProgressDialog *progressDialog = new ProgressDialog(this);
-    progressDialog->show();
-
-    int deleteFilesCount = 0;
-    bool deleteOk;
-    QList<int> rows;
-    int row;
-    QModelIndexList indexesList;
-    while ((indexesList = thumbsViewer->selectionModel()->selectedIndexes()).size()) {
-        QString fileNameFullPath = thumbsViewer->thumbsViewerModel->item(
-                indexesList.first().row())->data(thumbsViewer->FileNameRole).toString();
-        progressDialog->opLabel->setText("Deleting " + fileNameFullPath);
-        deleteOk = QFile::remove(fileNameFullPath);
-
-        ++deleteFilesCount;
-        if (deleteOk) {
-            row = indexesList.first().row();
-            rows << row;
-            thumbsViewer->thumbsViewerModel->removeRow(row);
-        } else {
-            QMessageBox msgBox;
-            msgBox.critical(this, tr("Error"), tr("Failed to delete image."));
-            break;
-        }
-
-        Settings::filesList.removeOne(fileNameFullPath);
-
-        if (progressDialog->abortOp) {
-            break;
-        }
-    }
-
-    if (thumbsViewer->thumbsViewerModel->rowCount()) {
-        qSort(rows.begin(), rows.end());
-        row = rows.at(0);
-
-        if (row >= thumbsViewer->thumbsViewerModel->rowCount()) {
-            row = thumbsViewer->thumbsViewerModel->rowCount() - 1;
-        }
-
-        thumbsViewer->setCurrentRow(row);
-        thumbsViewer->selectThumbByRow(row);
-    }
-
-    progressDialog->close();
-    delete (progressDialog);
-
-    QString state = QString(tr("Deleted") + " " + tr("%n image(s)", "", deleteFilesCount));
-    setStatus(state);
+    deleteFromThumbsViewer(true);
 }
 
 void Phototonic::goTo(QString path) {
@@ -1894,22 +1922,32 @@ void Phototonic::setDeleteAction(bool setEnabled) {
     deleteAction->setEnabled(setEnabled);
 }
 
+void Phototonic::setMoveToTrashAction(bool setEnabled) {
+    moveToTrashAction->setEnabled(setEnabled);
+}
+
 void Phototonic::updateActions() {
     if (QApplication::focusWidget() == thumbsViewer) {
-        setCopyCutActions(thumbsViewer->selectionModel()->selectedIndexes().size() > 0);
-        setDeleteAction(thumbsViewer->selectionModel()->selectedIndexes().size() > 0);
+        bool hasSelectedItems = thumbsViewer->selectionModel()->selectedIndexes().size() > 0;
+        setCopyCutActions(hasSelectedItems);
+        setDeleteAction(hasSelectedItems);
+        setMoveToTrashAction(hasSelectedItems);
     } else if (QApplication::focusWidget() == bookmarks) {
         setCopyCutActions(false);
         setDeleteAction(bookmarks->selectionModel()->selectedIndexes().size() > 0);
+        setMoveToTrashAction(false);
     } else if (QApplication::focusWidget() == fileSystemTree) {
         setCopyCutActions(false);
         setDeleteAction(fileSystemTree->selectionModel()->selectedIndexes().size() > 0);
+        setMoveToTrashAction(false);
     } else if (Settings::layoutMode == ImageViewWidget || QApplication::focusWidget() == imageViewer->scrollArea) {
         setCopyCutActions(false);
         setDeleteAction(true);
+        setMoveToTrashAction(true);
     } else {
         setCopyCutActions(false);
         setDeleteAction(false);
+        setMoveToTrashAction(false);
     }
 
     if (Settings::layoutMode == ImageViewWidget && !interfaceDisabled) {
@@ -3310,6 +3348,7 @@ void Phototonic::setInterfaceEnabled(bool enable) {
     copyToAction->setEnabled(enable);
     moveToAction->setEnabled(enable);
     deleteAction->setEnabled(enable);
+    moveToTrashAction->setEnabled(enable);
     settingsAction->setEnabled(enable);
     viewImageAction->setEnabled(enable);
 

--- a/Phototonic.h
+++ b/Phototonic.h
@@ -145,6 +145,8 @@ private slots:
 
     void deleteOperation();
 
+    void moveToTrashOperation();
+
     void cutThumbs();
 
     void copyThumbs();
@@ -285,6 +287,7 @@ private:
     QAction *copyToAction;
     QAction *moveToAction;
     QAction *deleteAction;
+    QAction *moveToTrashAction;
     QAction *saveAction;
     QAction *saveAsAction;
     QAction *renameAction;
@@ -428,7 +431,9 @@ private:
 
     void setupDocks();
 
-    void viewerDeleteFromViewer();
+    void deleteFromThumbsViewer(bool trash);
+
+    void viewerDeleteFromViewer(bool trash);
 
     void loadCurrentImage(int currentRow);
 
@@ -473,6 +478,8 @@ private:
     void setCopyCutActions(bool setEnabled);
 
     void setDeleteAction(bool setEnabled);
+
+    void setMoveToTrashAction(bool setEnabled);
 
     void wheelEvent(QWheelEvent *event);
 

--- a/Trashcan.cpp
+++ b/Trashcan.cpp
@@ -1,0 +1,124 @@
+#include <QtGlobal>
+#include "Trashcan.h"
+
+#if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID) && !defined(Q_OS_DARWIN)
+
+#include <QDateTime>
+#include <QDir>
+#include <QFileInfo>
+#include <QFile>
+#include <QStandardPaths>
+#include <QStorageInfo>
+#include <QTextStream>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <cerrno>
+
+static Trash::Result moveToTrashDir(const QString& filePath, const QDir& trashDir, QString& error)
+{
+    const QDir trashInfoDir = QDir(trashDir.filePath("info"));
+    const QDir trashFilesDir = QDir(trashDir.filePath("files"));
+    if (trashInfoDir.mkpath(".") && trashFilesDir.mkpath(".")) {
+        QFileInfo fileInfo(filePath);
+        QString fileName = fileInfo.fileName();
+        QString infoFileName = fileName + ".trashinfo";
+        int fd;
+        const int flag = O_CREAT | O_WRONLY | O_EXCL;
+        const int mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+        for (unsigned int n = 2; trashFilesDir.exists(fileName) ||
+             ((fd = open(trashInfoDir.filePath(infoFileName).toUtf8().data(), flag, mode)) == -1 && errno == EEXIST); ++n) {
+            fileName = QString("%1.%2.%3").arg(fileInfo.baseName(), QString::number(n), fileInfo.completeSuffix());
+            infoFileName = fileName + ".trashinfo";
+        }
+        if (fd == -1) {
+            error = strerror(errno);
+            return Trash::Error;
+        }
+        const QString moveHere = trashFilesDir.filePath(fileName);
+        const QString deletionDate = QDateTime::currentDateTime().toString(Qt::ISODate);
+        QString escapedPath = filePath;
+        escapedPath.replace('\\', "\\").replace('\n', "\\n").replace('\r', "\\r").replace('\t', "\\t");
+        QFile infoFile;
+        if (infoFile.open(fd, QIODevice::WriteOnly, QFileDevice::AutoCloseHandle)) {
+            QTextStream out(&infoFile);
+            out << "[Trash Info]\nPath=" << escapedPath << "\nDeletionDate=" << deletionDate << '\n';
+        } else {
+            error = infoFile.errorString();
+            return Trash::Error;
+        }
+
+
+        if (QDir().rename(filePath, moveHere)) {
+            return Trash::Success;
+        } else {
+            error = QString("Could not rename %1 to %2").arg(filePath, moveHere);
+            return Trash::Error;
+        }
+    } else {
+        error = "Could not set up trash subdirectories";
+        return Trash::Error;
+    }
+}
+
+Trash::Result Trash::moveToTrash(const QString &path, QString &error, Trash::Options trashOptions)
+{
+    if (path.isEmpty()) {
+        error = "Path is empty";
+        return Trash::Error;
+    }
+    const QString filePath = QFileInfo(path).absoluteFilePath();
+    const QStorageInfo filePathStorage(filePath);
+    if (!filePathStorage.isValid()) {
+        error = "Could not get device of the file being trashed";
+        return Trash::Error;
+    }
+    const QString homeDataLocation = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+    const QDir homeDataDirectory(homeDataLocation);
+    if (homeDataLocation.isEmpty() || !homeDataDirectory.exists()) {
+        error = "Could not get home data folder";
+        return Trash::Error;
+    }
+
+    if (QStorageInfo(homeDataLocation) == filePathStorage || trashOptions == Trash::ForceDeletionToHomeTrash) {
+        const QDir homeTrashDirectory = QDir(homeDataDirectory.filePath("Trash"));
+        if (homeTrashDirectory.mkpath(".")) {
+            return moveToTrashDir(filePath, homeTrashDirectory, error);
+        } else {
+            error = "Could not ensure that home trash directory exists";
+            return Trash::Error;
+        }
+    } else {
+        const QDir topdir = QDir(filePathStorage.rootPath());
+        const QDir topdirTrash = QDir(topdir.filePath(".Trash"));
+        struct stat trashStat;
+        if (lstat(topdirTrash.path().toUtf8().data(), &trashStat) == 0) {
+            // should be a directory, not link, and have sticky bit
+            if (S_ISDIR(trashStat.st_mode) && !S_ISLNK(trashStat.st_mode) && (trashStat.st_mode & S_ISVTX)) {
+                const QString subdir = QString::number(getuid());
+                if (topdirTrash.mkpath(subdir)) {
+                    return moveToTrashDir(filePath, QDir(topdirTrash.filePath(subdir)), error);
+                }
+            }
+        }
+        // if we're still here, $topdir/.Trash does not exist or failed some check
+        QDir topdirUserTrash = QDir(topdir.filePath(QString(".Trash-%1").arg(getuid())));
+        if (topdirUserTrash.mkpath(".")) {
+            return moveToTrashDir(filePath, topdirUserTrash, error);
+        }
+        error = "Could not find trash directory for the disk where the file resides";
+        return Trash::NeedsUserInput;
+    }
+}
+
+#else
+
+Trash::Result Trash::moveToTrash(const QString &path, QString &error, Trash::Options trashOptions)
+{
+    error = "Putting files into trashcan is not supported for this platform yet";
+    return Trash::Error;
+}
+
+#endif

--- a/Trashcan.h
+++ b/Trashcan.h
@@ -1,0 +1,23 @@
+#ifndef TRASHCAN_H
+#define TRASHCAN_H
+
+#include <QString>
+
+namespace Trash {
+    typedef enum
+    {
+        Success,
+        Error,
+        NeedsUserInput
+    } Result;
+
+    typedef enum
+    {
+        NoOptions = 0,
+        ForceDeletionToHomeTrash = 1
+    } Options;
+
+    Trash::Result moveToTrash(const QString &filePath, QString &error, Options trashOptions = NoOptions);
+}
+
+#endif // TRASHCAN_H

--- a/phototonic.pro
+++ b/phototonic.pro
@@ -30,13 +30,15 @@ CONFIG += c++11
 HEADERS += SettingsDialog.h Phototonic.h ThumbsViewer.h ImageViewer.h CropRubberband.h Settings.h InfoViewer.h \
 			FileSystemTree.h Bookmarks.h DirCompleter.h Tags.h MetadataCache.h ShortcutsTable.h CopyMoveDialog.h \
 			CopyMoveToDialog.h CropDialog.h ProgressDialog.h ColorsDialog.h ResizeDialog.h ExternalAppsDialog.h \
-			ImagePreview.h FileSystemModel.h FileListWidget.h RenameDialog.h
+			ImagePreview.h FileSystemModel.h FileListWidget.h RenameDialog.h \
+    Trashcan.h
 
 SOURCES += SettingsDialog.cpp main.cpp Phototonic.cpp ThumbsViewer.cpp ImageViewer.cpp CropRubberband.cpp \
 			Settings.cpp InfoViewer.cpp FileSystemTree.cpp Bookmarks.cpp DirCompleter.cpp Tags.cpp \
 			MetadataCache.cpp ShortcutsTable.cpp CopyMoveDialog.cpp CopyMoveToDialog.cpp CropDialog.cpp \
 			ProgressDialog.cpp ExternalAppsDialog.cpp ColorsDialog.cpp ResizeDialog.cpp ImagePreview.cpp \
-			FileSystemModel.cpp FileListWidget.cpp RenameDialog.cpp
+			FileSystemModel.cpp FileListWidget.cpp RenameDialog.cpp \
+    Trashcan.cpp
 
 RESOURCES += phototonic.qrc
 


### PR DESCRIPTION
Related issue #211 

Implementation for Windows will be easier to add, because it has ready API for that.

I did not add any shortcut for this operation, choose it on your own. Probably you want to leave just one button and give a user a choice in settings - to always permanently delete files or always move them to trashcan. Decide it yourself.