### PR TITLE
Fix crash when could not delete image. Don't use persistent QImageRea…

### DIFF
--- a/ImagePreview.cpp
+++ b/ImagePreview.cpp
@@ -45,7 +45,7 @@ ImagePreview::ImagePreview(QWidget *parent) : QWidget(parent) {
 }
 
 QPixmap& ImagePreview::loadImage(QString imageFileName) {
-    imageReader.setFileName(imageFileName);
+    QImageReader imageReader(imageFileName);
     if (imageReader.size().isValid()) {
         QSize resize = imageReader.size();
         resize.scale(QSize(imageLabel->width(), imageLabel->height()), Qt::KeepAspectRatio);

--- a/ImagePreview.h
+++ b/ImagePreview.h
@@ -42,7 +42,6 @@ protected:
 
 private:
     QLabel *imageLabel;
-    QImageReader imageReader;
     QPixmap previewPixmap;
 
 };

--- a/ImageViewer.cpp
+++ b/ImageViewer.cpp
@@ -627,7 +627,7 @@ void ImageViewer::reload() {
         return;
     }
 
-    imageReader.setFileName(viewerImageFullPath);
+    QImageReader imageReader(viewerImageFullPath);
     if (Settings::enableAnimations && imageReader.supportsAnimation()) {
         if (animation) {
             delete animation;

--- a/ImageViewer.h
+++ b/ImageViewer.h
@@ -127,7 +127,6 @@ protected:
 
 private:
     Phototonic *phototonic;
-    QImageReader imageReader;
     QLabel *imageLabel;
     QPixmap viewerPixmap;
     QImage origImage;

--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -1711,8 +1711,16 @@ void Phototonic::deleteFromThumbsViewer(bool trash)
         QString fileNameFullPath = thumbsViewer->thumbsViewerModel->item(
                 indexesList.first().row())->data(thumbsViewer->FileNameRole).toString();
         progressDialog->opLabel->setText("Deleting " + fileNameFullPath);
-        QString trashError;
-        deleteOk = trash ? (Trash::moveToTrash(fileNameFullPath, trashError) == Trash::Success) : QFile::remove(fileNameFullPath);
+        QString deleteError;
+        if (trash) {
+            deleteOk = Trash::moveToTrash(fileNameFullPath, deleteError) == Trash::Success;
+        } else {
+            QFile fileToRemove(fileNameFullPath);
+            deleteOk = fileToRemove.remove();
+            if (!deleteOk) {
+                deleteError = fileToRemove.errorString();
+            }
+        }
 
         ++deleteFilesCount;
         if (deleteOk) {
@@ -1721,7 +1729,7 @@ void Phototonic::deleteFromThumbsViewer(bool trash)
             thumbsViewer->thumbsViewerModel->removeRow(row);
         } else {
             QMessageBox msgBox;
-            msgBox.critical(this, tr("Error"), trash ? trashError : tr("Failed to delete image."));
+            msgBox.critical(this, tr("Error"), (trash ? tr("Failed to move image to trash can") : tr("Failed to delete image.")) + "\n" + deleteError );
             break;
         }
 
@@ -1732,7 +1740,7 @@ void Phototonic::deleteFromThumbsViewer(bool trash)
         }
     }
 
-    if (thumbsViewer->thumbsViewerModel->rowCount()) {
+    if (thumbsViewer->thumbsViewerModel->rowCount() && rows.count()) {
         qSort(rows.begin(), rows.end());
         row = rows.at(0);
 

--- a/ThumbsViewer.cpp
+++ b/ThumbsViewer.cpp
@@ -165,7 +165,7 @@ bool ThumbsViewer::setCurrentIndexByRow(int row) {
 
 void ThumbsViewer::updateImageInfoViewer(QString imageFullPath) {
 
-    imageInfoReader.setFileName(imageFullPath);
+    QImageReader imageInfoReader(imageFullPath);
     QString key;
     QString val;
 
@@ -601,7 +601,7 @@ void ThumbsViewer::selectThumbByRow(int row) {
 
 void ThumbsViewer::loadThumbsRange() {
     static bool isInProgress = false;
-    static QImageReader thumbReader;
+    QImageReader thumbReader;
     static QSize currentThumbSize;
     static int currentRowCount;
     static QString imageFileName;

--- a/ThumbsViewer.h
+++ b/ThumbsViewer.h
@@ -128,7 +128,6 @@ private:
     QFileInfoList thumbFileInfoList;
     QImage emptyImg;
     QModelIndex currentIndex;
-    QImageReader imageInfoReader;
     Phototonic *phototonic;
     MetadataCache *metadataCache;
     ImageViewer *imageViewer;


### PR DESCRIPTION
…der objects in order to avoid file locking on Windows

Crash was caused by calling `rows.at` when it has zero size.