### PR TITLE
Arrows work with ALT modifier

### DIFF
--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -2425,6 +2425,15 @@ void Phototonic::mousePressEvent(QMouseEvent *event) {
     }
 }
 
+void Phototonic::keyPressEvent(QKeyEvent *event) {
+	if (event->key() == Qt::Key_Left) {
+		loadPreviousImage();
+   } else if (event->key() == Qt::Key_Right) {
+		loadNextImage();
+   }
+   event->accept();
+}
+
 void Phototonic::newImage() {
     if (Settings::layoutMode == ThumbViewWidget) {
         showViewer();

--- a/Phototonic.h
+++ b/Phototonic.h
@@ -61,6 +61,8 @@ protected:
     void closeEvent(QCloseEvent *event);
 
     void mousePressEvent(QMouseEvent *event);
+    
+    void keyPressEvent(QKeyEvent *event);
 
 public slots:
 


### PR DESCRIPTION
I like very much this image viewer but I miss the simple left/right navigation when images are open. I tried to implement it but for some reason it works only with Alt modifier. Ignore the `event->accept();`

Can you help? 

Thanks anyway for your work :-)