### PR TITLE
fix segfault when thumbnails autorotate activated

### DIFF
--- a/Phototonic.cpp
+++ b/Phototonic.cpp
@@ -297,6 +297,7 @@ void Phototonic::createImageViewer() {
     imageViewer->setContextMenuPolicy(Qt::DefaultContextMenu);
     Settings::isFullScreen = Settings::appSettings->value(Settings::optionFullScreenMode).toBool();
     fullScreenAction->setChecked(Settings::isFullScreen);
+    thumbsViewer->setImageViewer(imageViewer);
     thumbsViewer->imagePreview->setImageViewer(imageViewer);
 }
 


### PR DESCRIPTION
Phototonic segfaults on startup when the autorotate option is activated for thumbnails. This is caused by an access to an uninitialized member imageViewer of a ThumbsViewer object. This patch makes the required initialization.